### PR TITLE
1.7.0 dns_selectel:

### DIFF
--- a/api/dns_selectel/examples/get-domains.ps1
+++ b/api/dns_selectel/examples/get-domains.ps1
@@ -4,7 +4,8 @@ Param(
     [String]$domain='',
     [String]$ver='v2',
     [switch]$v,
-    [hashtable]$ExP=@{}
+    [hashtable]$ExP=@{},
+    [string]$act='gds'
 )
 
 $r1=(.\rest-api.ps1 -Provider 'dns_selectel' `
@@ -25,7 +26,7 @@ $r1=(.\rest-api.ps1 -Provider 'dns_selectel' `
                 '_Query'='show_ips=true&limit=2';
                 '_record_id'=11264554 `
     } + $ExP)`
-    -Action 'gds' `
+    -Action $act `
     -debug `
     -Verbose:$v `
     -LogLevel 1


### PR DESCRIPTION
    Добавил функцию Get-DomainsAll. В этой функции теперь обрабатываются limit и offset и правильно считываются большие количества доменов
    Теперь две точки API:
    domains (gds, Get-Domains)- считать все записи о доменах
    domainsPart (gdsp, Get-DomainsPart) - считать записи о доменах по данным параметров запроса &limit=n&offset=k